### PR TITLE
fix: Support parsing inline-table format of Poetry dependency spec

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -44,7 +44,10 @@ namespace.configure(
 with open("pyproject.toml", "r", encoding="utf8") as pyproject:
     parsed_toml = toml.load(pyproject)
 
-NAUTOBOT_VERSION = parsed_toml["tool"]["poetry"]["dependencies"]["nautobot"]
+try:
+    NAUTOBOT_VERSION = parsed_toml["tool"]["poetry"]["dependencies"]["nautobot"]["version"]
+except TypeError:
+    NAUTOBOT_VERSION = parsed_toml["tool"]["poetry"]["dependencies"]["nautobot"]
 
 
 def task(function=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg


### PR DESCRIPTION
Suggested fix for #70. This allows for the Nautobot module dependency defined in `pyproject.toml` to be parsed successfully both in its string form and its inline-table form.

If a user wants extras included with the Nautobot dependency, such as "napalm" or "remote_storage", they will appear in `pyproject.toml` like so:

```toml
nautobot = {version = "2.1.1", extras = ["napalm"]}
```

`toml.load` will represent this as a dict-like object. We can try to parse it as a dict first, then fall back to parsing it as a string. As far as I know, these should be the only two forms the version value will come in for _most_ use cases. [Multiple constraints](https://python-poetry.org/docs/dependency-specification/#multiple-constraints-dependencies) bring a list-of-dicts form as well, but I'd imagine that's more of a fringe case.

-----

I would also advise considering the possibility of users supplying one of the [different possible version strings](https://python-poetry.org/docs/dependency-specification/#version-constraints). For example, if a user wants to add the 'napalm' extra to their Nautobot dependency, they would most likely do so with the `poetry add` command:

```bash
poetry add nautobot[napalm]
```

Since no version is specified, Poetry defaults to setting the version string to `^(current version)`, i.e. `^2.2.2`. That caret is going to throw a wrench in Docker's rendering of the Nautobot image URL:

https://github.com/nautobot/nautobot-docker-compose/blob/40eec0879a0e8f271eedcaf0f67ade55166ca6b5/environments/Dockerfile#L1-L3

The resolution for this comes down to the project's preference. If you want to constrain the dependency versioning to only using a static version, I think raising a warning to the user would suffice. Otherwise, you'd have to tackle the less trivial task of parsing `poetry.lock` for the resolved Nautobot module version.