### PR TITLE
Loosen dependency version

### DIFF
--- a/plugins/plugin_example/pyproject.toml
+++ b/plugins/plugin_example/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Network to Code <info@networktocode.com>"]
 [tool.poetry.dependencies]
 python = "^3.8,<3.12"
 nautobot = "^2.0.0"
-nautobot-device-onboarding = "^3.0.0"
+nautobot-device-onboarding = ">=3.0.0,<5.0.0"
 
 [tool.poetry.dev-dependencies]
 bandit = "*"


### PR DESCRIPTION
With the release of device onboarding v4.0, the version requirements need to be loosened in the example plugin.

resolves #81 