### PR TITLE
readme new user updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The reason it was chosen over Makefile was due to our collective familiarity wit
 
 This repo is designed to provide a custom build of Nautobot to include a set of plugins which can then be used in a development environment or deployed in production.  Included in this repo is a skeleton Nautobot plugin which is designed only to provide a quick example of how a plugin could be developed.  Plugins should ultimately be built as packages, published to a PyPI style repository and added to the poetry `pyproject.toml` in this repo.  The plugin code should be hosted in their own repositories with their own CI pipelines and not included here.
 
+Are you installing Nautobot for the first time to locally try out the application? After installing Poetry and Docker, jump down to [Getting Started](#getting-started) for a step-by-step guide to install the application. 
+
+If you want to play with a cloud instance, you can always access [the Nautobot Demo Instance](https://demo.nautobot.com/) online. 
+
 ## Install Docker
 
 Before beginning, install Docker and verify its operation by running `docker run hello-world`. If you encounter any issues connecting to the Docker service, check that your local user account is permitted to run Docker. **Note:** `docker` v1.10.0 or later is required.
@@ -183,6 +187,8 @@ The use of LDAP requires the installation of some additional libraries and some 
 The installation of plugins has a slightly more involved getting-started process. See the [Plugin documentation](docs/plugins.md).
 
 ## Super User Account
+
+If you are testing the application locally, you will need to create a super user below in order to authenticate to the application, even if the credential files are already created from the previous steps.
 
 ### Create Super User via Environment
 


### PR DESCRIPTION
Hi!

First off, great job on the documentation and project! Really well done in terms of technology choices and usability. It was super simple to get up and going with Docker / Poetry / Invoke. 

When I was following the README installing with Docker Compose Nautobot, I noticed a few minor improvements that could be made. Feel free to use other verbiage or other ways of solving the same issue. 

Basically 2 things about the install process could be improved:

## Main README

1. Going through the README top to bottom, I ensured Docker, Poetry and Invoke were installed, which had great instructions. Then after reading `## Install Poetry`, I assumed the next step was `## Build and start Nautobot` and was confused why things were not working, especially with the phrase `Nautobot will be available on port 8080 locally http://localhost:8080`, I assumed I had done something wrong. 

I then realized after scrolling through several more subsections, after doing some troubleshooting that there was a full `## Getting Started` section that I didn't see and included important steps like copying the `.env` files and such. Once I followed those steps everything worked well. 

In order to call attention to the Getting Started part, I added some explanation early on `## How to use this repo` part, though including a table of contents to show people that the Getting Started part is way far down the README is another option. 

2. After getting the app installed, I couldn't authenticate. I was confused because in the getting started guide the credential files I copied seemed to have usernames and passwords in them. I saw at the end `## Super User Account`, but did not realize it was a required step if I wanted to authenticate into the app. 

For the sake of clarity, I added a phrase at the beginning of that section to let people know this is required if you are testing locally, the credential files are not enough. 

