### PR TITLE
Remove need for distutils.util (distutils now deprecated)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = ["John Doe <johndoe@mail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 nautobot = "2.3.6"
-setuptools = ">=75.6.0"
 
 # nautobot-example-plugin = {path = "plugins/plugin_example", develop = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["John Doe <johndoe@mail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 nautobot = "2.3.6"
+setuptools = ">=75.6.0"
 
 # nautobot-example-plugin = {path = "plugins/plugin_example", develop = true}
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,5 @@
 """Development Tasks."""
 
-from distutils.util import strtobool
 from time import sleep
 import os
 import toml
@@ -19,7 +18,14 @@ def is_truthy(arg):
     """
     if isinstance(arg, bool):
         return arg
-    return bool(strtobool(arg))
+
+    val = str(arg).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"Invalid truthy value: `{arg}`")
 
 
 # Use pyinvoke configuration for default values, see http://docs.pyinvoke.org/en/stable/concepts/configuration.html


### PR DESCRIPTION
Use setuptools to provide distutils.util (distutils deprecated w/ python >=3.12)

Tested with [Getting Started](https://github.com/nautobot/nautobot-docker-compose?tab=readme-ov-file#getting-started) steps, briefly:
- Edited env files
- poetry shell
- poetry lock
- poetry install
- invoke build start

**Before:**
```
Traceback (most recent call last):
  File "/home/chris/.cache/pypoetry/virtualenvs/nautobot-docker-compose-67IBQzlA-py3.12/bin/invoke", line 8, in <module>
    sys.exit(program.run())
             ^^^^^^^^^^^^^
  File "/home/chris/.cache/pypoetry/virtualenvs/nautobot-docker-compose-67IBQzlA-py3.12/lib/python3.12/site-packages/invoke/program.py", line 387, in run
    self.parse_collection()
  File "/home/chris/.cache/pypoetry/virtualenvs/nautobot-docker-compose-67IBQzlA-py3.12/lib/python3.12/site-packages/invoke/program.py", line 479, in parse_collection
    self.load_collection()
  File "/home/chris/.cache/pypoetry/virtualenvs/nautobot-docker-compose-67IBQzlA-py3.12/lib/python3.12/site-packages/invoke/program.py", line 716, in load_collection
    module, parent = loader.load(coll_name)
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/.cache/pypoetry/virtualenvs/nautobot-docker-compose-67IBQzlA-py3.12/lib/python3.12/site-packages/invoke/loader.py", line 91, in load
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/chris/repos/nautobot-docker-compose/tasks.py", line 3, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils'
```

**After:**
```
#22 [nautobot] resolving provenance for metadata file
 Service nautobot  Built
#22 DONE 0.0s
Starting Nautobot in detached mode...
Running docker compose command "up --detach"
 Network nautobot-docker-compose_default  Creating
 Network nautobot-docker-compose_default  Created
 Container nautobot-docker-compose-redis-1  Creating
 Container nautobot-docker-compose-db-1  Creating
 Container nautobot-docker-compose-db-1  Created
 Container nautobot-docker-compose-redis-1  Created
 Container nautobot-docker-compose-nautobot-1  Creating
 Container nautobot-docker-compose-nautobot-1  Created
 Container nautobot-docker-compose-celery_beat-1  Creating
 Container nautobot-docker-compose-celery_worker-1  Creating
 Container nautobot-docker-compose-celery_worker-1  Created
 Container nautobot-docker-compose-celery_beat-1  Created
 Container nautobot-docker-compose-redis-1  Starting
 Container nautobot-docker-compose-db-1  Starting
 Container nautobot-docker-compose-redis-1  Started
 Container nautobot-docker-compose-db-1  Started
 Container nautobot-docker-compose-nautobot-1  Starting
 Container nautobot-docker-compose-nautobot-1  Started
 Container nautobot-docker-compose-nautobot-1  Waiting
 Container nautobot-docker-compose-nautobot-1  Waiting
 Container nautobot-docker-compose-nautobot-1  Healthy
 Container nautobot-docker-compose-celery_beat-1  Starting
 Container nautobot-docker-compose-nautobot-1  Healthy
 Container nautobot-docker-compose-celery_worker-1  Starting
 Container nautobot-docker-compose-celery_beat-1  Started
 Container nautobot-docker-compose-celery_worker-1  Started
```

